### PR TITLE
Jethro Fixes 3

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/4/707.json
+++ b/config/betterquesting/DefaultQuests/Quests/4/707.json
@@ -7,7 +7,7 @@
       "desc:8": "susy.quest.db.707.desc",
       "frame:8": "GATE",
       "icon:10": {
-        "Damage:2": 1,
+        "Damage:2": 2,
         "id:8": "gregtech:wire_coil"
       },
       "name:8": "susy.quest.db.707.title"

--- a/config/betterquesting/DefaultQuests/Quests/4/708.json
+++ b/config/betterquesting/DefaultQuests/Quests/4/708.json
@@ -7,7 +7,7 @@
       "desc:8": "susy.quest.db.708.desc",
       "frame:8": "GATE",
       "icon:10": {
-        "Damage:2": 2,
+        "Damage:2": 1,
         "id:8": "gregtech:wire_coil"
       },
       "ismain:1": 1,

--- a/groovy/classes/ChangeFlags.groovy
+++ b/groovy/classes/ChangeFlags.groovy
@@ -204,6 +204,7 @@ class ChangeFlags {
         Invar.addFlags("disable_decomposition")
         Nichrome.addFlags("disable_decomposition")
         Kanthal.addFlags("disable_decomposition")
+        Electrum.addFlags("induction_melt")
 
         /*
         ManganesePhosphide.addFlags("no_smashing", "no_smelting")

--- a/groovy/postInit/chemistry/ChemistryOverhaul.groovy
+++ b/groovy/postInit/chemistry/ChemistryOverhaul.groovy
@@ -3621,3 +3621,13 @@ ROASTER.recipeBuilder()
     .duration(100)
     .EUt(VA[LV])
     .buildAndRegister()
+
+// Ammonium Fluoride
+
+MIXER.recipeBuilder()
+    .inputs(ore('dustAmmoniumFluoride') * 6)
+    .fluidInputs(fluid('water') * 1000)
+    .fluidOutputs(fluid('ammonium_fluoride_solution') * 1000)
+    .duration(60)
+    .EUt(VA[LV])
+    .buildAndRegister()

--- a/groovy/postInit/materials/metallurgy/MiscAlloys.groovy
+++ b/groovy/postInit/materials/metallurgy/MiscAlloys.groovy
@@ -67,7 +67,6 @@ INDUCTION_FURNACE.recipeBuilder()
     .fluidInputs(fluid('silver') * 144)
     .inputs(item('minecraft:gold_ingot'))
     .fluidOutputs(fluid('electrum') * 288)
-    .temperature(1235)
     .EUt(VA[LV])
     .buildAndRegister()    
 

--- a/groovy/postInit/materials/metallurgy/MiscAlloys.groovy
+++ b/groovy/postInit/materials/metallurgy/MiscAlloys.groovy
@@ -63,6 +63,14 @@ RESISTANCE_FURNACE.recipeBuilder()
     .EUt(VA[LV])
     .buildAndRegister()
 
+INDUCTION_FURNACE.recipeBuilder()
+    .fluidInputs(fluid('silver') * 144)
+    .inputs(item('minecraft:gold_ingot'))
+    .fluidOutputs(fluid('electrum') * 288)
+    .temperature(1235)
+    .EUt(VA[LV])
+    .buildAndRegister()    
+
 // Monel
 INDUCTION_FURNACE.recipeBuilder()
     .fluidInputs(fluid('nickel') * 3312)

--- a/groovy/postInit/materials/metallurgy/Quenching.groovy
+++ b/groovy/postInit/materials/metallurgy/Quenching.groovy
@@ -25,14 +25,11 @@ QuenchingFluid Brine = new QuenchingFluid('brine', 'warm_brine', 1000, 150.0, fa
 def ingotMap = [
     'Europium':6000,
     'Iridium':4500,
-    'Molybdenum':2890,
     'Niobium':2750,
     'Osmium':4500,
     'Rhodium':2237,
     'Ruthenium':2607,
     'Samarium':5400,
-    'Tantalum':3293,
-    'Thorium':2028,
     'Titanium':2141,
     'Tungsten':3600,
     'Vanadium':2183,
@@ -65,14 +62,7 @@ def ingotMap = [
     'RhodiumPlatedPalladium':4500,
     'Hssg':4200,
     'Hsse':5000,
-    'Hsss':5000,
-    'Monel500':3000,
-    'Hsla980X':2600,
-    'FoodGradeStainlessSteel':2600,
-    'PlatinumRhodium':2113,
-    'Zircaloy4':2200,
-    'ReactorSteel':1800,
-    'Alnico':1800
+    'Hsss':5000
 ]
 
 def electrodeMap = [

--- a/groovy/postInit/materials/metallurgy/Quenching.groovy
+++ b/groovy/postInit/materials/metallurgy/Quenching.groovy
@@ -95,6 +95,15 @@ for (fluid in QuenchingFluid.quenching_fluids) {
         .buildAndRegister();
 
     CHEMICAL_BATH.recipeBuilder()
+        .inputs(ore('ingotHotNichrome'))
+        .fluidInputs(liquid(fluid.getColdFluid()) * fluid.amount)
+        .outputs(metaitem('ingotNichrome'))
+        .fluidOutputs(liquid(fluid.getHotFluid()) * fluid.amount)
+        .duration((int) fluid.getDuration() * 4)
+        .EUt(VA[MV])
+        .buildAndRegister();
+
+    CHEMICAL_BATH.recipeBuilder()
         .inputs(ore('ingotHotAlnico'))
         .fluidInputs(liquid(fluid.getColdFluid()) * fluid.amount)
         .outputs(metaitem('ingotAlnico'))

--- a/groovy/prePostInit/OreDict.groovy
+++ b/groovy/prePostInit/OreDict.groovy
@@ -1,6 +1,5 @@
-package prePostInit;
+package prePostInit
 
-import static globals.Globals.*
 
 import supersymmetry.common.blocks.SuSyBlocks
 import supersymmetry.common.blocks.SusyStoneVariantBlock

--- a/groovy/prePostInit/OreDict.groovy
+++ b/groovy/prePostInit/OreDict.groovy
@@ -1,5 +1,6 @@
 package prePostInit
 
+import static globals.Globals.*
 
 import supersymmetry.common.blocks.SuSyBlocks
 import supersymmetry.common.blocks.SusyStoneVariantBlock

--- a/groovy/prePostInit/oreDict.groovy
+++ b/groovy/prePostInit/oreDict.groovy
@@ -159,6 +159,7 @@ ore('oreSedimentaryDeposit').add(item('susy:deposit_block:2'))
 ore('oreHydrothermalDeposit').add(item('susy:deposit_block:3'))
 ore('oreAlluvialDeposit').add(item('susy:deposit_block:4'))
 ore('oreMagmaticHydrothermalDeposit').add(item('susy:deposit_block:5'))
+ore('oreEvaporiteDeposit').add(item('susy:deposit_block:7'))
 
 // Bauxite the special little snowflake
 ore('oreBauxite').add(item('susy:resource_block:0'))


### PR DESCRIPTION
## What
* "Better Coils" and "Even Better Coils" quests now have the correct input.
* Evaporite Deposit blocks can now be seen via the Ore Prospector.
* Exorcised ghost recipes from the Quencher JEI tab.
* Electrum has been added to the Induction Furnace.
* Hot Nichrome ingots can now be cooled down in a chemical bath.
* Ammonium Fluoride now has a non-byproduct crafting path.
* oreDict.groovy has been renamed to OreDict.groovy so that it runs earlier (should fix issues with kanthal/nichrome springs).